### PR TITLE
feat: implementacao excluir anunciante

### DIFF
--- a/controllers/anunciante_controller.php
+++ b/controllers/anunciante_controller.php
@@ -76,7 +76,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             $anuncianteModel->criar($dadosAnunciante);
 
-
             $conexao->commit();
 
             header("Location: ../views/form_anunciante.php?msg=success");
@@ -88,6 +87,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             error_log("Erro ao CADASTRAR anunciante: " . $e->getMessage());
             header("Location: ../views/form_anunciante.php?msg=error&erro=" . urlencode($e->getMessage()));
             exit;
+        }
+    }
+
+    if ($acao === 'excluir') {
+        $publicacaoId = $_POST['publicacaoid'] ?? null;
+        if ($publicacaoId) {
+            try {
+                $conexao->beginTransaction();
+                // Exclui anunciante primeiro (por causa da FK)
+                $anuncianteModel->excluir($publicacaoId);
+                // Exclui publicação
+                $publicacaoModel->excluir($publicacaoId);
+                $conexao->commit();
+                header("Location: ../views/listar_anunciantes.php?msg=success");
+                exit;
+            } catch (Exception $e) {
+                if ($conexao->inTransaction()) {
+                    $conexao->rollBack();
+                }
+                error_log("Erro ao EXCLUIR anunciante/publicação: " . $e->getMessage());
+                header("Location: ../views/listar_anunciantes.php?msg=error&erro=" . urlencode($e->getMessage()));
+                exit;
+            }
         }
     }
 }

--- a/models/anunciante_model.php
+++ b/models/anunciante_model.php
@@ -20,4 +20,10 @@ class AnuncianteModel
             ':banner' => $dados['banner']
         ]);
     }
+
+    public function excluir($publicacaoid)
+    {
+        $stmt = $this->conexao->prepare("DELETE FROM anunciante WHERE publicacaoid = :publicacaoid");
+        return $stmt->execute([':publicacaoid' => $publicacaoid]);
+    }
 }

--- a/models/publicacao_model.php
+++ b/models/publicacao_model.php
@@ -27,7 +27,7 @@ class PublicacaoModel
                     a.anunciantebanner
                 FROM 
                     publicacao p
-                LEFT JOIN 
+                INNER JOIN 
                     anunciante a ON p.publicacaoid = a.publicacaoid
                 ORDER BY 
                     p.publicacaoid DESC
@@ -102,5 +102,11 @@ class PublicacaoModel
         $stmt->bindParam(':id', $id);
         $stmt->execute();
         return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function excluir($publicacaoid)
+    {
+        $stmt = $this->conexao->prepare("DELETE FROM publicacao WHERE publicacaoid = :publicacaoid");
+        return $stmt->execute([':publicacaoid' => $publicacaoid]);
     }
 }

--- a/views/listar_anunciantes.php
+++ b/views/listar_anunciantes.php
@@ -160,8 +160,11 @@ if (isset($_GET['msg'])) {
 <body class="min-h-screen">
 
     <div class="container mx-auto px-4 py-12 max-w-7xl">
-        <?php if ($mensagem): ?>
-        <?php endif; ?>
+        <!-- Toast de confirmação -->
+        <div id="toast-success" class="fixed top-6 right-6 z-50 hidden bg-green-500 text-white px-6 py-3 rounded shadow-lg flex items-center space-x-2">
+            <i class="fas fa-check-circle"></i>
+            <span id="toast-msg">Anunciante excluído com sucesso!</span>
+        </div>
 
         <div class="flex justify-center space-x-4 mb-8" id="botoes">
             <a href="navegacao_forms.php" class="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400 transition flex items-center space-x-2"><i class="fas fa-arrow-left"></i><span>Voltar</span></a>
@@ -252,6 +255,7 @@ if (isset($_GET['msg'])) {
                             <form method="POST" action="../controllers/anunciante_controller.php" onsubmit="return confirm('Tem certeza que deseja excluir este anúncio?');">
                                 <input type="hidden" name="acao" value="excluir">
                                 <input type="hidden" name="publicacao_id" value="<?= $anuncio['publicacaoid'] ?>">
+                                <input type="hidden" name="publicacaoid" value="<?= $anuncio['publicacaoid'] ?>">
                                 <button type="submit" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">Excluir</button>
                             </form>
                             <a href="form_anunciante.php?editar=true&publicacao_id=<?= $anuncio['publicacaoid'] ?>" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Editar</a>
@@ -268,7 +272,17 @@ if (isset($_GET['msg'])) {
     </div>
 
     <script>
-        function abrirModal(modalId) {
+        // Exibe o toast se houver mensagem de sucesso
+        <?php if (isset($_GET['msg']) && $_GET['msg'] === 'success'): ?>
+        document.addEventListener('DOMContentLoaded', function() {
+            var toast = document.getElementById('toast-success');
+            toast.style.display = 'flex';
+            setTimeout(function() {
+                toast.style.display = 'none';
+            }, 3000);
+        });
+        <?php endif; ?>
+    function abrirModal(modalId) {
             document.getElementById(modalId).style.display = 'block';
             document.body.style.overflow = 'hidden';
         }


### PR DESCRIPTION
- Implementa funcionalidade de exclusão de anunciante e sua publicação, incluindo métodos excluir nas models AnuncianteModel e PublicacaoModel.

- Adiciona lógica no controller para excluir ambos os registros de forma segura, respeitando as restrições de chave estrangeira.

- Corrige o formulário de exclusão no modal, garantindo o envio correto do publicacaoid.

- Adiciona um toast de confirmação visual para informar ao usuário sobre a exclusão bem-sucedida.

- Ajusta a query de listagem para exibir apenas publicações que possuem anunciante (INNER JOIN).

- Melhora a experiência do usuário e a integridade dos dados.